### PR TITLE
adding lemma AB = 0 and weak safety verification

### DIFF
--- a/picus/r1cs-z3-interpreter.rkt
+++ b/picus/r1cs-z3-interpreter.rkt
@@ -145,15 +145,20 @@
         ;     )
         ; ))
         ; optimized & simplified form
-        (define ret-cnst (format "(assert (= 0 ~a))\n"
-            (format "(mod ~a ~a)"
-                (if (equal? "0" sum-c)
-                    (format "~a" (opt-format-mul sum-a sum-b))
-                    (format "(- ~a ~a)" (opt-format-mul sum-a sum-b) sum-c)
+        (define ret-cnst 
+            (if (equal? "0" sum-c)
+                (format "(assert (or (= 0 (mod ~a ~a)) (= 0 (mod ~a ~a))))\n"
+                    sum-a
+                    config:p
+                    sum-b
+                    config:p
                 )
-                config:p
+                (format "(assert (= 0 (mod ~a ~a)))\n"
+                    (format "(- ~a ~a)" (opt-format-mul sum-a sum-b) sum-c)
+                    config:p
+                )
             )
-        ))
+        )
 
 
         ; return this assembled constraint

--- a/picus/utils.rkt
+++ b/picus/utils.rkt
@@ -10,6 +10,16 @@
         )
     )
 )
+
+; auxiliar function to check if the intersection of two sets is empty
+(define (empty_inter? l1 l2) 
+    (cond ((null? l1) #t)
+        ((contains? l2 (car l1)) #f)
+       (else (empty_inter? (cdr l1) l2))
+    )
+)
+
+
 (define (slice l offset n) (take (drop l offset) n))
 
 ; (note) this is little endian (i.e., little bytes come first)

--- a/test-z3-inc-uniqueness.rkt
+++ b/test-z3-inc-uniqueness.rkt
@@ -63,6 +63,10 @@
     (when verbose?
         (printf "# written to: ~a\n" temp-path)
     )
+<<<<<<< HEAD
+    (printf "# written to: ~a\n" temp-path)
+=======
+>>>>>>> 89d898ebc681d7d93c59bfad4218817c8b89fa10
     (when verbose?
         (printf "# solving...\n")
     )
@@ -232,6 +236,11 @@
 (define res-ul (inc-solve known-list unknown-list))
 (printf "# final unknown list: ~a\n" res-ul)
 (if (empty? res-ul)
-    (printf "# verified.\n")
-    (printf "# failed.\n")
+    (printf "# Strong safety verified.\n")
+    (printf "# Strong safey failed.\n")
+)
+
+(if (utils:empty_inter? res-ul output-list)
+    (printf "# Weak safety verified.\n")
+    (printf "# Weak safey failed.\n")
 )

--- a/test-z3-inc-uniqueness.rkt
+++ b/test-z3-inc-uniqueness.rkt
@@ -63,10 +63,6 @@
     (when verbose?
         (printf "# written to: ~a\n" temp-path)
     )
-<<<<<<< HEAD
-    (printf "# written to: ~a\n" temp-path)
-=======
->>>>>>> 89d898ebc681d7d93c59bfad4218817c8b89fa10
     (when verbose?
         (printf "# solving...\n")
     )

--- a/test-z3-inc-uniqueness.rkt
+++ b/test-z3-inc-uniqueness.rkt
@@ -152,7 +152,7 @@
 ; keep track of index of xlist (not xlist0 since that's incomplete)
 (define known-list (filter
     (lambda (x) (! (null? x)))
-    (for/list ([i (range (+ 1 nwires))])
+    (for/list ([i (range nwires)])
         (if (utils:contains? xlist0 (list-ref xlist i))
             i
             null
@@ -161,7 +161,7 @@
 ))
 (define unknown-list (filter
     (lambda (x) (! (null? x)))
-    (for/list ([i (range (+ 1 nwires))])
+    (for/list ([i (range nwires)])
         (if (utils:contains? xlist0 (list-ref xlist i))
             null
             i


### PR DESCRIPTION
- Adding the lemma A * B = 0 imples A = 0 or B = 0: everytime we find a constraint with that format we substitute it by A = 0 or B = 0
- Adding weak safety analysis: check if the set of signals that we could not prove unique contains outputs 