### PR TITLE
BUG FIX: basis2 lemma only valid for bit sizes < 254.

### DIFF
--- a/picus/algorithms/lemmas/basis2-lemma.rkt
+++ b/picus/algorithms/lemmas/basis2-lemma.rkt
@@ -30,7 +30,7 @@
     (values tmp-ks tmp-us)
 )
 
-(define basis2-seqs (for/set ([i (range 270)])
+(define basis2-seqs (for/set ([i (range 253)])
     (for/set ([j (range (+ 1 i))])
         (expt 2 j)
     )


### PR DESCRIPTION
This basis2 lemma only holds for bit lengths less than the bit length of the underlying prime field. 